### PR TITLE
Add password to user

### DIFF
--- a/lib/tsheets/models/user.rb
+++ b/lib/tsheets/models/user.rb
@@ -6,7 +6,7 @@ class TSheets::Models::User < TSheets::Model
   field :first_name, :string
   field :last_name, :string
   field :group_id, :integer
-  field :manager_of_group_ids, [ :integer ]
+  field :manager_of_group_ids, [ :integer ], exclude: [:add, :edit]
   field :employee_number, :integer
   field :salaried, :boolean
   field :exempt, :boolean
@@ -15,13 +15,13 @@ class TSheets::Models::User < TSheets::Model
   field :mobile_number, :string
   field :hire_date, :date
   field :term_date, :date
-  field :last_active, :datetime
+  field :last_active, :datetime, exclude: [:add, :edit]
   field :active, :boolean
   field :require_password_change, :boolean
   field :approved_to, :date
   field :submitted_to, :date
-  field :last_modified, :datetime
-  field :created, :datetime
+  field :last_modified, :datetime, exclude: [:add, :edit]
+  field :created, :datetime, exclude: [:add, :edit]
   field :permissions, :user_permissions_set
 
 end

--- a/lib/tsheets/models/user.rb
+++ b/lib/tsheets/models/user.rb
@@ -1,6 +1,7 @@
 class TSheets::Models::User < TSheets::Model
   field :id, :integer
   field :username, :string
+  field :password
   field :email, :string
   field :first_name, :string
   field :last_name, :string
@@ -22,5 +23,5 @@ class TSheets::Models::User < TSheets::Model
   field :last_modified, :datetime
   field :created, :datetime
   field :permissions, :user_permissions_set
-  
+
 end

--- a/lib/tsheets/models/user.rb
+++ b/lib/tsheets/models/user.rb
@@ -1,7 +1,7 @@
 class TSheets::Models::User < TSheets::Model
   field :id, :integer
   field :username, :string
-  field :password
+  field :password, :string
   field :email, :string
   field :first_name, :string
   field :last_name, :string


### PR DESCRIPTION
A call to `TSHEETS_API.users.insert` with a user object will always fail, since there is no password field on the user model. This pull request adds a password field to the user model, and marks several of the fields that are not allowed for an add or edit request as excluded.