### PR TITLE
Change Fixnum to Integer to avoid deprecation warnings

### DIFF
--- a/lib/tsheets/repository.rb
+++ b/lib/tsheets/repository.rb
@@ -5,7 +5,7 @@ class TSheets::Repository
 
   @@allowed_classes_for_spec = {
     boolean: [ ::TrueClass, ::FalseClass ],
-    integer: [ ::Fixnum ],
+    integer: [ ::Integer ],
     string:  [ ::String, ::Symbol ],
     date:    [ ::Date ],
     datetime: [ ::DateTime ]


### PR DESCRIPTION
This is to avoid the following deprecation warning that pops up repeatedly when running Rails tasks:
```
/home/user/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/api_ruby-5f9fb0372485/lib/tsheets/repository.rb:8: warning: constant ::Fixnum is deprecated
```