### PR TITLE
security/CVE-2020-8130: update version on rake dependency

### DIFF
--- a/lib/tsheets/version.rb
+++ b/lib/tsheets/version.rb
@@ -1,3 +1,3 @@
 module Tsheets
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end

--- a/tsheets.gemspec
+++ b/tsheets.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "backports"
 
   spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 12.3"
+  spec.add_development_dependency "rake", "~> 12.3", ">= 12.3.3" # 12.3.3 fixes CVE-2020-8130
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-mocks"
   spec.add_development_dependency "pry"

--- a/tsheets.gemspec
+++ b/tsheets.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "backports"
 
   spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.3"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-mocks"
   spec.add_development_dependency "pry"


### PR DESCRIPTION
Updated the version for our rake dependency from `~> 10.0` to `~ 12.3`, `>= 12.3.3`. This is to address vulnerability https://nvd.nist.gov/vuln/detail/CVE-2020-8130.